### PR TITLE
Don't use boolean values of databases and tables

### DIFF
--- a/thingy.py
+++ b/thingy.py
@@ -167,19 +167,19 @@ class DatabaseThingy(NamesMixin, Thingy):
 
     @classmethod
     def get_database(cls):
-        if cls._database:
+        if cls._database is not None:
             return cls._database
         return cls._get_database(cls._table, cls.database_name)
 
     @classmethod
     def get_table(cls):
-        if cls._table:
+        if cls._table is not None:
             return cls._table
         return cls._get_table(cls.database, cls.table_name)
 
     @classmethod
     def get_database_name(cls):
-        if cls._database:
+        if cls._database is not None:
             return cls._get_database_name(cls._database)
         if cls._database_name:
             return cls._database_name
@@ -190,11 +190,11 @@ class DatabaseThingy(NamesMixin, Thingy):
 
     @classmethod
     def get_table_name(cls):
-        if cls._table:
+        if cls._table is not None:
             return cls._get_table_name(cls._table)
         if cls._table_name:
             return cls._table_name
-        if cls._database or cls._database_name:
+        if cls._database is not None or cls._database_name:
             return "_".join(cls.names)
         return cls.names[-1]
 


### PR DESCRIPTION
Hi,

I'm implementing a thingy wrapper for TinyDB and its database class have a `__len__` method returning the number of document in the default table. It means that evaluated in a boolean context, a database might be considered `False`.

With the current implementation, a database evaluated to `False` represents no database, and I think we can improve to only consider that there is no database, when the attribute `_database` is `None`.

I did apply the same reasonning to tables, but not to database and table names, since it would seem silly to use empty names.